### PR TITLE
add name subcategory, generated exception in freepbx.

### DIFF
--- a/endpoint/grandstream/bts/template_data.json
+++ b/endpoint/grandstream/bts/template_data.json
@@ -5,6 +5,7 @@
         "name":"general",
         "subcategory":[
           {
+            "name":"General Settings",
             "item":[
               {
                 "description":"General Settings",


### PR DESCRIPTION
Hi @billsimon,
I'm updating the endpointman module for FreeBPX 17 and I've noticed that the json is missing the section name and it generates an exception in the import process.
This PR adds the missing tag.

I don't know if this is the correct branch to send the PR to, let me know if I have to change branches.